### PR TITLE
feat: structed log

### DIFF
--- a/pkg/driver/provisioner.go
+++ b/pkg/driver/provisioner.go
@@ -65,7 +65,7 @@ func (s *ProvisionerServer) ProvisionerCreateBucket(ctx context.Context,
 	err := s.s3Client.CreateBucket(bucketName)
 	if err != nil {
 		// Check to see if the bucket already exists by above api
-		klog.ErrorS(err, "failed to create bucket %q", bucketName)
+		klog.ErrorS(err, "failed to create bucket", "bucketName", bucketName)
 		return nil, status.Error(codes.Internal, "failed to create bucket")
 	}
 	klog.Infof("Successfully created Backend Bucket %q", bucketName)

--- a/pkg/util/s3client/s3-handlers.go
+++ b/pkg/util/s3client/s3-handlers.go
@@ -77,9 +77,9 @@ func (s *S3Agent) CreateBucket(name string) error {
 
 func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 	if infoLogging {
-		klog.Infof("creating bucket %q", name)
+		klog.InfoS("creating bucket", "name", name)
 	} else {
-		klog.Infof("creating bucket %q", name)
+		klog.InfoS("creating bucket", "name", name)
 	}
 	bucketInput := &s3.CreateBucketInput{
 		Bucket: &name,
@@ -87,13 +87,13 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 	_, err := s.Client.CreateBucket(bucketInput)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			klog.Infof("DEBUG: after s3 call, ok=%v, aerr=%v", ok, aerr)
+			klog.InfoS("DEBUG: after s3 call", "ok", ok, "aerr", aerr)
 			switch aerr.Code() {
 			case s3.ErrCodeBucketAlreadyExists:
-				klog.Infof("bucket %q already exists", name)
+				klog.InfoS("bucket already exists", "name", name)
 				return nil
 			case s3.ErrCodeBucketAlreadyOwnedByYou:
-				klog.Infof("bucket %q already owned by you", name)
+				klog.InfoS("bucket already owned by you", "name", name)
 				return nil
 			}
 		}
@@ -101,9 +101,9 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 	}
 
 	if infoLogging {
-		klog.Infof("successfully created bucket %q", name)
+		klog.InfoS("successfully created bucket", "name", name)
 	} else {
-		klog.Infof("successfully created bucket %q", name)
+		klog.InfoS("successfully created bucket", "name", name)
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func (s *S3Agent) DeleteBucket(name string) (bool, error) {
 		Bucket: aws.String(name),
 	})
 	if err != nil {
-		klog.Errorf("failed to delete bucket. %v", err)
+		klog.ErrorS(err, "failed to delete bucket")
 		return false, err
 
 	}
@@ -131,7 +131,7 @@ func (s *S3Agent) PutObjectInBucket(bucketname string, body string, key string,
 		ContentType: &contentType,
 	})
 	if err != nil {
-		klog.Errorf("failed to put object in bucket. %v", err)
+		klog.ErrorS(err, "failed to put object in bucket")
 		return false, err
 
 	}
@@ -146,7 +146,7 @@ func (s *S3Agent) GetObjectInBucket(bucketname string, key string) (string, erro
 	})
 
 	if err != nil {
-		klog.Errorf("failed to retrieve object from bucket. %v", err)
+		klog.ErrorS(err, "failed to retrieve object from bucket")
 		return "ERROR_ OBJECT NOT FOUND", err
 
 	}
@@ -174,7 +174,7 @@ func (s *S3Agent) DeleteObjectInBucket(bucketname string, key string) (bool, err
 				return true, nil
 			}
 		}
-		klog.Errorf("failed to delete object from bucket. %v", err)
+		klog.ErrorS(err, "failed to delete object from bucket")
 		return false, err
 
 	}


### PR DESCRIPTION
ErrorS is not like Errorf 
it will print error log like this 
```bash
E1112 10:13:32.364480       1 provisioner.go:68] "failed to create bucket %q" err="failed to create bucket \"test-3a089556-038d-4950-b304-ff53326b6e5a\" error RequestError: send request failed\ncaused by: Put \"http://rgw:8080/test-3a089556-038d-4950-b304-ff53326b6e5a\": dial tcp: lookup rgw on 10.96.0.10:53: no such host" test-3a089556-038d-4950-b304-ff53326b6e5a="(MISSING)"
```