### PR TITLE
add github action for releasing ceph cosi driver

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,67 @@
+---
+name: Build and release versioned container images
+
+# yamllint disable-line rule:truthy
+on:
+  create
+
+jobs:
+  tag_image:
+    name: Build and release the bundle container-image
+    if: >
+      github.repository == 'ceph/ceph-cosi'
+      &&
+      github.ref_type  == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Generate the container image
+        run: make container
+
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build bundle container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: quay.io/ceph/cosi:${{ github.ref_name }}
+
+  publish_release:
+    name: Publish a release based on the tag
+    if: >
+      github.repository == 'ceph/ceph-cosi'
+      &&
+      github.ref_type  == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Publish the release and attach YAML files
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          artifacts: "examples/*/*.yaml"
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github action will push image to quay.io/ceph/cosi repo and tag release in github.