### PR TITLE
include example files in the release

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -71,6 +71,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ github.ref_name }}
-          artifacts: "examples/*/*.yaml"
+          artifacts: "examples/*.yaml"
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The github action to include examples file is failing due to wrong path