### PR TITLE
update container build to use builder pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,43 @@
-FROM gcr.io/distroless/static:latest
+#
+# BUILDER
+#
+
+FROM golang:1.22 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ceph-cosi-driver cmd/ceph-cosi-driver/*.go
+
+#
+# FINAL IMAGE
+#
+
+# Use distroless as minimal base image to package the binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+
 LABEL maintainers="Ceph COSI Authors"
 LABEL description="Ceph COSI driver"
 
-COPY ./bin/ceph-cosi-driver ceph-cosi-driver
+WORKDIR /
+COPY --from=builder /workspace/ceph-cosi-driver .
+USER 65532:65532
+
 ENTRYPOINT ["/ceph-cosi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,10 @@ build-%:
 		CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*-ppc64le ./cmd/$* ; \
 	fi
 
-container-%: build-%
-	$(CONTAINER_CMD) build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .
-
 build: $(CMDS:%=build-%)
-container: $(CMDS:%=container-%)
+
+container:
+	$(CONTAINER_CMD) build --tag ceph-cosi-driver:latest --label revision=$(REV) .
 
 clean:
 	-rm -rf bin


### PR DESCRIPTION
Update the Dockerfile (and thus Makefile) to use the container builder pattern. This makes it easy to build a container image for any architecture, and it makes it certain that the binary built matches the container.

Importantly, this should fix the ARM builds that are currently broken.