### PR TITLE
update github actions to use approved versions

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -26,14 +26,14 @@ jobs:
         run: make container
 
       - name: Login to quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Set up QEMU for multi-arch builds
         uses: docker/setup-qemu-action@v3
@@ -41,36 +41,10 @@ jobs:
           platforms: 'arm64'
 
       - name: Build bundle container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: Dockerfile
           push: true
           tags: quay.io/ceph/cosi:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
-
-  publish_release:
-    name: Publish a release based on the tag
-    if: >
-      github.repository == 'ceph/ceph-cosi'
-      &&
-      github.ref_type  == 'tag'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - name: Publish the release and attach YAML files
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ github.ref_name }}
-          artifacts: "examples/*.yaml"
-          generateReleaseNotes: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -20,14 +20,9 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: '3.19.6'
-
       - name: Run "make vet"
         run: make vet
-      
+
       - name: Run "make fmt"
         run: make fmt
 


### PR DESCRIPTION
Update github actions jobs to use approved action versions. Remove unnecessary job steps that use unapproved actions.