### PR TITLE
set missed docker/setup-qemu-action to sha version

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: 'arm64'
 


### PR DESCRIPTION
Set the docker/setup-qemu-action to an approved SHA version. This was missed in the last update.

The process should also be less confusing for users now as well. Tag `v0.1.3` was pushed but failed. Recently, `v0.1.4-rc1` was pushed, which also failed, but since this is `-rc1`, users should not mistake it for a release that is expected to be available.